### PR TITLE
Add Documentation generation

### DIFF
--- a/bingoggles/__init__.py
+++ b/bingoggles/__init__.py
@@ -1,4 +1,3 @@
-from . import bingoggles_types
 from .bingoggles_types import *
 from .auxiliary import *
 from . import auxiliary

--- a/bingoggles/modules.py
+++ b/bingoggles/modules.py
@@ -1,13 +1,10 @@
-from bingoggles_types import *
 from binaryninja.enums import MediumLevelILOperation
 from binaryninja.mediumlevelil import MediumLevelILVar
+from binaryninja.enums import MediumLevelILOperation
+from binaryninja.mediumlevelil import MediumLevelILVar
+
 from bingoggles.auxiliary import func_name_to_object
-
-
-from bingoggles_types import *
-from binaryninja.enums import MediumLevelILOperation
-from binaryninja.mediumlevelil import MediumLevelILVar
-
+from bingoggles.bingoggles_types import *
 
 class UseAfterFreeDetection:
     def __init__(self, bv, slice_data: dict):

--- a/bingoggles/vfa.py
+++ b/bingoggles/vfa.py
@@ -564,11 +564,8 @@ class Analysis:
         whether it influences other parameter paths.
 
         Args:
-            function_node (int | Function): The target function, specified either by its starting address (int)
-                                                or as a Binary Ninja Function object.
-            tainted_params (Variable | str | list[Variable]): The parameter(s) to check for taint. This can be a single
-                                                            Variable object, a string representing the parameter name,
-                                                            or a list of Variable objects.
+            function_node (int | Function): The target function, specified either by its starting address (int) or as a Binary Ninja Function object.
+            tainted_params (Variable | str | list[Variable]): The parameter(s) to check for taint. This can be a single Variable object, a string representing the parameter name, or a list of Variable objects.
             origin_function (Function): This parameter is used for internal tracking and paremeter matching (do not touch this parameter).
             tainted_param_map (dict): A dictionary mapping original parameters to their tainted parameters.
 

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -1,0 +1,20 @@
+# Minimal makefile for Sphinx documentation
+#
+
+# You can set these variables from the command line, and also
+# from the environment for the first two.
+SPHINXOPTS    ?=
+SPHINXBUILD   ?= sphinx-build
+SOURCEDIR     = source
+BUILDDIR      = build
+
+# Put it first so that "make" without argument is like "make help".
+help:
+	@$(SPHINXBUILD) -M help "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
+
+.PHONY: help Makefile
+
+# Catch-all target: route all unknown targets to Sphinx using the new
+# "make mode" option.  $(O) is meant as a shortcut for $(SPHINXOPTS).
+%: Makefile
+	@$(SPHINXBUILD) -M $@ "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)

--- a/docs/make.bat
+++ b/docs/make.bat
@@ -1,0 +1,35 @@
+@ECHO OFF
+
+pushd %~dp0
+
+REM Command file for Sphinx documentation
+
+if "%SPHINXBUILD%" == "" (
+	set SPHINXBUILD=sphinx-build
+)
+set SOURCEDIR=source
+set BUILDDIR=build
+
+%SPHINXBUILD% >NUL 2>NUL
+if errorlevel 9009 (
+	echo.
+	echo.The 'sphinx-build' command was not found. Make sure you have Sphinx
+	echo.installed, then set the SPHINXBUILD environment variable to point
+	echo.to the full path of the 'sphinx-build' executable. Alternatively you
+	echo.may add the Sphinx directory to PATH.
+	echo.
+	echo.If you don't have Sphinx installed, grab it from
+	echo.https://www.sphinx-doc.org/
+	exit /b 1
+)
+
+if "%1" == "" goto help
+
+%SPHINXBUILD% -M %1 %SOURCEDIR% %BUILDDIR% %SPHINXOPTS% %O%
+goto end
+
+:help
+%SPHINXBUILD% -M help %SOURCEDIR% %BUILDDIR% %SPHINXOPTS% %O%
+
+:end
+popd

--- a/docs/source/bingoggles.rst
+++ b/docs/source/bingoggles.rst
@@ -1,0 +1,45 @@
+bingoggles package
+==================
+
+Submodules
+----------
+
+bingoggles.auxiliary module
+---------------------------
+
+.. automodule:: bingoggles.auxiliary
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+bingoggles.bingoggles\_types module
+-----------------------------------
+
+.. automodule:: bingoggles.bingoggles_types
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+bingoggles.modules module
+-------------------------
+
+.. automodule:: bingoggles.modules
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+bingoggles.vfa module
+---------------------
+
+.. automodule:: bingoggles.vfa
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+Module contents
+---------------
+
+.. automodule:: bingoggles
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -1,0 +1,39 @@
+# Configuration file for the Sphinx documentation builder.
+#
+# For the full list of built-in configuration values, see the documentation:
+# https://www.sphinx-doc.org/en/master/usage/configuration.html
+
+# -- Project information -----------------------------------------------------
+# https://www.sphinx-doc.org/en/master/usage/configuration.html#project-information
+
+import os
+import sys
+
+sys.path.insert(0, os.path.abspath("../../"))
+
+project = 'BinGoggles'
+copyright = '2025, pwnpope'
+author = 'pwnpope'
+release = '0.0.2'
+
+# -- General configuration ---------------------------------------------------
+# https://www.sphinx-doc.org/en/master/usage/configuration.html#general-configuration
+
+extensions = [
+	"sphinx.ext.autodoc",
+	"sphinx.ext.autosummary",
+	"sphinx_autodoc_typehints",
+]
+
+autosummary_generate = True
+
+templates_path = ['_templates']
+exclude_patterns = []
+
+
+
+# -- Options for HTML output -------------------------------------------------
+# https://www.sphinx-doc.org/en/master/usage/configuration.html#options-for-html-output
+
+html_theme = 'sphinx_rtd_theme'
+html_static_path = ['_static']

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -3,8 +3,41 @@
    You can adapt this file completely to your liking, but it should at least
    contain the root `toctree` directive.
 
-Welcome to BinGoggles's documentation!
+BinGoggles's Documentation
 ======================================
+
+The Assumed Taint Analysis Engine
+
+Using BinGoggles with `Hugsy Headless <https://github.com/hugsy/binja-headless>`_
+---------------------------------------------------------------------------------
+
+
+.. code-block:: python
+
+	from bingoggles.bingoggles_types import *
+	from os import abspath
+
+	test_bin = "./test/binaries/bin/test_mlil_store"
+	bg_init = BGInitRpyc(
+		target_bin=abspath(test_bin),
+		libraries=["/lib/x86_64-linux-gnu/libc.so.6"],
+		host="127.0.0.1",
+		port=18812,
+	)
+
+	bn, bv, libraries_mapped = bg_init.init()
+
+	analysis = Analysis(
+		binaryview=bv, binaryninja=bn, verbose=True, libraries_mapped=libraries_mapped
+	)
+
+	analysis.tainted_slice(
+		target=TaintTarget(0x00401212, "rdi"),
+		var_type=SlicingID.FunctionVar,
+		output=OutputMode.Printed,
+	)
+
+
 
 .. toctree::
    :maxdepth: 2

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -1,0 +1,20 @@
+.. BinGoggles documentation master file, created by
+   sphinx-quickstart on Fri May  9 01:42:55 2025.
+   You can adapt this file completely to your liking, but it should at least
+   contain the root `toctree` directive.
+
+Welcome to BinGoggles's documentation!
+======================================
+
+.. toctree::
+   :maxdepth: 2
+   :caption: Contents:
+
+
+
+Indices and tables
+==================
+
+* :ref:`genindex`
+* :ref:`modindex`
+* :ref:`search`

--- a/docs/source/modules.rst
+++ b/docs/source/modules.rst
@@ -1,0 +1,7 @@
+bingoggles
+==========
+
+.. toctree::
+   :maxdepth: 4
+
+   bingoggles

--- a/requirements-sphinx.txt
+++ b/requirements-sphinx.txt
@@ -1,0 +1,3 @@
+sphinx
+sphinx-autodoc-typehints
+sphinx_rtd_theme


### PR DESCRIPTION
Make sure to install to the `requirements-sphinx.txt` python packages.

Update the documentation with: `cd docs && sphinx-apidoc -o source/ ../bingoggles`
You can then run `make html` from within the `docs` folder; you can then host an http server from `docs/build/html`